### PR TITLE
Restore compatibility with Python 2

### DIFF
--- a/addon/globalPlugins/sayProductNameAndVersion.py
+++ b/addon/globalPlugins/sayProductNameAndVersion.py
@@ -22,7 +22,7 @@ addonHandler.initTranslation()
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __init__(self, *args, **kwargs):
-		super().__init__()
+		super(GlobalPlugin, self).__init__()
 
 	@script(
 		category=SCRCAT_TOOLS,

--- a/buildVars.py
+++ b/buildVars.py
@@ -24,7 +24,7 @@ addon_info = {
 	"addon_description" : _("""Say product name and version of the application which ownes the focused window.
 Default shortcut: Shift+NVDA+V"""),
 	# version
-	"addon_version" : "2023.3.2",
+	"addon_version" : "2023.3.3",
 	# Author(s)
 	"addon_author" : "Patrick ZAJDA <patrick@zajda.fr>, Luke Davis <XLTechie@newanswertech.com>",
 	# URL for the add-on documentation support

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+Note: language-only releases are not included here.
+
+#### 2023.3.3
+
+* Restored Python 2.7 compatibility at user and original author request. (#3)
+
 #### 2023.3.1
 
 * Luke Davis has taken over maintenance of the add-on.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,3 @@
-[[!meta title="Say Product Name and Version"]]
-
 * Author: Patrick ZAJDA <patrick@zajda.fr>, Luke Davis <XLTechie@newanswertech.com>
 * NVDA compatibility: 2017.3 or later
 * Download [stable version][1]
@@ -13,6 +11,4 @@ This shortcut may be remapped in the Tools category of NVDA's Input Gestures.
 
 For change history, please read the [changelog](https://github.com/opensourcesys/sayProductNameAndVersion/blob/master/changelog.md#readme).
 
-[[!tag stable]]
-
-[1]: https://addons.nvda-project.org/files/get.php?file=sayProductNameAndVersion
+[1]: https://www.nvaccess.org/addonStore/legacy?file=sayProductNameAndVersion


### PR DESCRIPTION
Hello

Issue found while testing NVDA 2019.2.1:
This add-on is advertised to be compatible with 2017.3 onwards. But it is actually not compatible with Python 2, i.e. 2019.2.1 or below.

This PR fixes the issue: `super` should be called with arguments in Python 2.

Note that maintaining compatibility of add-ons with so old versions of NVDA is not needed for the vast majority of people. However, in the case of this specific add-on, the cost to keep this compatibility is very low.

